### PR TITLE
Move images to IBM Cloud Container Registry

### DIFF
--- a/.github/workflows/build-and-publish-to-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-to-dockerhub.yaml
@@ -15,8 +15,9 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: icr.io
+          username: ${{ secrets.ICR_USERNAME }}
+          password: ${{ secrets.ICR_TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ resource_types:
   - name: instana-pipeline-feedback
     type: docker-image
     source:
-      repository: instana/pipeline-feedback-resource
+      repository: icr.io/instana/pipeline-feedback-resource
       tag: latest
 
 resources:
@@ -137,7 +137,7 @@ The test scripts assumes a local Docker daemon.
 
 ## Releasing
 
-The Docker image for the resource is automatically built and pushed to [Docker Hub](https://hub.docker.com/r/instana/pipeline-feedback-resource) when a new [GitHub release](https://github.com/instana/pipeline-feedback-resource/releases) is published (draft releases are not built and pushed to Docker Hub).
+The Docker image for the resource is automatically built and pushed to IBM Cloud Container Registry. The images are publicly available via `icr.io/instana/pipeline-feedback-resource` when a new [GitHub release](https://github.com/instana/pipeline-feedback-resource/releases) is published (draft releases are not built and pushed to IBM Cloud Container Registry).
 
 ## Contributing
 

--- a/examples/test-pipeline.yaml
+++ b/examples/test-pipeline.yaml
@@ -4,7 +4,7 @@ resource_types:
   - name: instana-pipeline-feedback
     type: docker-image
     source:
-      repository: instana/pipeline-feedback-resource
+      repository: icr.io/instana/pipeline-feedback-resource
       tag: latest
 
 resources:

--- a/tests/wrap_check
+++ b/tests/wrap_check
@@ -27,4 +27,4 @@ else
     }" > "${input_file}"
 fi
 
-docker run -i instana/pipeline-feedback-resource:latest bash -x /opt/resource/check < "${input_file}"
+docker run -i icr.io/instana/pipeline-feedback-resource:latest bash -x /opt/resource/check < "${input_file}"

--- a/tests/wrap_in
+++ b/tests/wrap_in
@@ -30,4 +30,4 @@ else
     }" > "${input_file}"
 fi
 
-docker run -i instana/pipeline-feedback-resource:latest bash -x /opt/resource/in "${3}" < "${input_file}"
+docker run -i icr.io/instana/pipeline-feedback-resource:latest bash -x /opt/resource/in "${3}" < "${input_file}"

--- a/tests/wrap_out
+++ b/tests/wrap_out
@@ -65,5 +65,5 @@ echo "{
         "--volume=${scope_file}:${scope_file}:ro"\
         "--volume=${release_name_file}:${release_name_file}:ro"\
         "--volume=${start_file}:${start_file}:ro"\
-        instana/pipeline-feedback-resource:latest \
+        icr.io/instana/pipeline-feedback-resource:latest \
         bash -x /opt/resource/out


### PR DESCRIPTION
# Why / What

In order to provide security scanned images and Docker Hub does not provide such a capability at the moment, the docker images will be pushed to IBM Cloud Container Registry. See https://cloud.ibm.com/docs/Registry?topic=va-va_index&interface=ui for further details.