### PR TITLE
Use valid ubuntu base version

### DIFF
--- a/.github/workflows/build-and-publish-to-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-to-dockerhub.yaml
@@ -25,6 +25,6 @@ jobs:
           build-args: |
             version=${{ github.event.release.tag_name }}
           push: true
-          tags: instana/pipeline-feedback-resource
+          tags: icr.io/instana/pipeline-feedback-resource
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-and-publish-to-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-to-dockerhub.yaml
@@ -1,4 +1,4 @@
-name: Build and publish image to Docker Hub
+name: Build and publish image to IBM Cloud Container Registry
 on:
   release:
     types: [published]
@@ -12,7 +12,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
+      - name: Login to IBM Cloud Container Registry
         uses: docker/login-action@v1 
         with:
           registry: icr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.10
 
 ARG version=dev
 ENV version=${version}


### PR DESCRIPTION
# Why / What

The ubuntu:20.10 base image reached end of life and is replaced with the latest ubuntu:21.10.
This PR also fixes minor issues like correct namings and the correct target repository `icr.io`.